### PR TITLE
Fix Stripe to Dodo Payments migration missing required fields

### DIFF
--- a/src/providers/stripe/index.ts
+++ b/src/providers/stripe/index.ts
@@ -288,13 +288,11 @@ async function migrateCoupons(stripe: Stripe, client: DodoPayments, brand_id: st
                 code: coupon.id,
                 name: coupon.name || coupon.id,
                 type: 'percentage',
-                discount_type: 'percentage',
-                discount_value: discountValue,
                 amount: Math.round(discountValue * 100), // Convert percentage to basis points (e.g., 15% = 1500 basis points) 
-                currency: coupon.currency?.toUpperCase() || 'USD',
                 usage_limit: coupon.max_redemptions || null,
                 expires_at: coupon.redeem_by ? new Date(coupon.redeem_by * 1000).toISOString() : null,
-                brand_id: brand_id
+                brand_id: brand_id,
+                displayValue: discountValue // For display purposes in the UI
             });
         }
 
@@ -305,10 +303,7 @@ async function migrateCoupons(stripe: Stripe, client: DodoPayments, brand_id: st
 
         console.log('\n[LOG] These are the coupons to be migrated:');
         CouponsToMigrate.forEach((coupon, index) => {
-            const discount = coupon.discount_type === 'percentage' 
-                ? `${coupon.discount_value}%` 
-                : `${coupon.currency} ${(coupon.discount_value / 100).toFixed(2)}`;
-            console.log(`${index + 1}. ${coupon.name} (${coupon.code}) - ${discount} discount`);
+            console.log(`${index + 1}. ${coupon.name} (${coupon.code}) - ${coupon.displayValue}% discount`);
         });
 
         const migrateCoupons = await select({


### PR DESCRIPTION
**Issue**: Migration script failed due to missing required fields in API payloads. #20  

**Root Cause**: Dodo Payments API required additional fields not included in the original mapping.

1. **Products**: Added `payment_frequency_count: 1` for subscription products
2. **Coupons**: 
   - Added `type: 'percentage'` field for percentage-based coupons
   - Added `amount: 1` field (required by API, in cents)
   - Improved handling of fixed amount vs percentage coupon types
   - error handling for already-existing discounts

**Results**: 
- Migration script now successfully creates products and percentage-based coupons
- Fixed amount coupons are gracefully skipped with clear user guidance
- All API field requirements properly satisfied





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recurring subscriptions now include an explicit payment frequency count (defaults to 1).
  - Coupons are standardized to percentage-based discounts with an explicit percentage/display value; expiration and brand association are preserved.

- **Bug Fixes**
  - Fixed-amount coupons are skipped with clear logs.
  - Migrating an already-existing coupon is logged and skipped instead of causing an error; overall coupon logging improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->