### PR TITLE
added subscription cycles

### DIFF
--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -242,7 +242,12 @@ export default {
                     subscriptionCycles = 1;
                 } else if (lsDuration === 'repeating') {
                     // "Repeating" uses the specific number of months from Lemon Squeezy
-                    subscriptionCycles = discount.attributes.duration_in_months;
+                    const durationMonths = discount.attributes.duration_in_months;
+                    if (typeof durationMonths !== 'number' || durationMonths <= 0) {
+                        console.log(`[WARNING] Invalid duration_in_months (${durationMonths}) for discount "${discount.attributes.name}" - skipping`);
+                        continue;
+                    }
+                    subscriptionCycles = durationMonths;
                 } else if (lsDuration === 'forever') {
                     // "Forever" is represented by null or undefined in Dodo
                     subscriptionCycles = null;


### PR DESCRIPTION
issue #28 
This adds subscription cycles support to discount coupons when migrating from lemonsqueezy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved discount and coupon migration for Lemon Squeezy: subscription cycle information is now computed and stored for one-time, repeating, and unlimited discounts.
  * Added validation for repeating-duration discounts; invalid durations are logged and skipped to avoid bad data.
  * Migration accuracy and consistency for coupons has been enhanced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->