### PR TITLE
feat: add license key migration for Polar and LemonSqueezy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Note: This tool is currently in Beta and may contain bugs. If you encounter any 
 - [x] Products
 - [x] Discount codes
 - [x] Customers
+- [x] License keys (Polar.sh, Lemon Squeezy)
 
 ## Contents
 - [Features](#features)

--- a/docs/lemonsqueezy/README.md
+++ b/docs/lemonsqueezy/README.md
@@ -9,12 +9,22 @@ dodo-migrate lemonsqueezy
 - Move one-time payment products from Lemon Squeezy to Dodo Payments
 - Move subscription products (monthly/yearly) from Lemon Squeezy to Dodo Payments
 - Move percentage-based coupons/discounts from Lemon Squeezy to Dodo Payments
+- Move customers from Lemon Squeezy to Dodo Payments
+- Move license keys from Lemon Squeezy to Dodo Payments
 
 #### Coupon Migration Details:
 - Only **published** coupons are migrated
 - Only **percentage-based** discounts are supported (fixed amount discounts are skipped with a warning)
 - Preserves expiration dates and usage limits
 - Maps discount codes and names accurately
+
+#### License Key Migration Details:
+- Requires products and customers to be migrated in the same session
+- Maps license keys to Dodo products and customers via in-memory ID maps
+- Activation limit of 0 in Lemon Squeezy is converted to unlimited (null) in Dodo
+- Disabled and expired keys are skipped with a warning
+- Duplicate keys (409) are handled gracefully for idempotent re-runs
+- License key activations (device instances) are not migrated — customers will need to re-activate
 
 #### Arguments (completely optional):
 | name | value | info

--- a/docs/polar/README.md
+++ b/docs/polar/README.md
@@ -1,6 +1,6 @@
 # Polar.sh Migration Guide
 
-Migrate products, discounts, and customers from Polar.sh to Dodo Payments with `dodo-migrate polar`.
+Migrate products, discounts, customers, and license keys from Polar.sh to Dodo Payments with `dodo-migrate polar`.
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ The CLI will guide you through:
 3. Select environment (test/live mode)
 4. Select organization (if you have multiple)
 5. Select brand
-6. Choose what to migrate (products, discounts, customers)
+6. Choose what to migrate (products, discounts, customers, license keys)
 7. Preview items
 8. Confirm and migrate
 
@@ -77,10 +77,11 @@ dodo-migrate polar \
 - Price amounts preserved in cents
 
 **Limitations:**
-- ⚠️ **Benefits not migrated** (license keys, GitHub access, file downloads, custom, etc.)
-  - Products with benefits will migrate successfully
+- ⚠️ **Non-license-key benefits not migrated** (GitHub access, file downloads, custom, etc.)
+  - Products with non-license-key benefits will migrate successfully
   - Warning logged for manual setup
   - Configure benefits manually in Dodo Payments after migration
+- License key benefits are migrated separately (see License Keys section below)
 - Weekly/daily recurring intervals not supported (only monthly/yearly)
 - Trial periods not migrated
 - Pay-what-you-want pricing → Skipped with warning
@@ -126,6 +127,31 @@ dodo-migrate polar \
 - Customers without email → Skipped with warning
 - Deleted customers → Skipped automatically
 
+### ✅ License Keys
+
+**What's Migrated:**
+- License key strings (imported via Dodo's import API, marked as `source: "import"`)
+- Activation limits
+- Expiration dates
+- Customer and product associations
+
+**Requirements:**
+- Products and customers must be migrated in the same session as license keys
+- The migration builds an in-memory mapping of Polar IDs → Dodo IDs
+- License keys are resolved from Polar benefits (benefit → product mapping built during product migration)
+
+**Transformations:**
+- Polar `benefit_id` → resolved to Dodo `product_id` via benefit-to-product mapping
+- Polar `customer_id` → mapped to Dodo `customer_id`
+- `limit_activations` → `activations_limit` (null = unlimited in both systems)
+- `expires_at` → direct mapping (ISO 8601, null = perpetual)
+
+**Limitations:**
+- ⚠️ **Revoked/disabled keys are skipped** (only `"granted"` status keys are migrated)
+- License key activations (device instances) are not migrated — customers will need to re-activate
+- Keys without a resolvable product or customer mapping are skipped with a warning
+- Usage counts (`usage`, `limit_usage`) are not migrated (Dodo tracks activations, not usage)
+
 ---
 
 ## CLI Arguments Reference
@@ -136,7 +162,7 @@ dodo-migrate polar \
 | `--dodo-api-key` | Dodo Payments API Key | Interactive: No<br>Non-interactive: Yes | Prompts in interactive mode |
 | `--dodo-brand-id` | Dodo Payments Brand ID | Interactive: No<br>Non-interactive: Yes | Prompts in interactive mode |
 | `--mode` | Environment: `test_mode` or `live_mode` | No | `test_mode` |
-| `--migrate-types` | Comma-separated: `products`, `discounts`, `customers` | No | Interactive: Prompts<br>Non-interactive: `products,discounts` |
+| `--migrate-types` | Comma-separated: `products`, `discounts`, `customers`, `license_keys` | No | Interactive: Prompts<br>Non-interactive: `products,discounts` |
 | `--polar-organization-id` | Polar organization ID (if multiple orgs) | Only if multiple orgs in non-interactive mode | Auto-select if single org |
 
 ---
@@ -221,17 +247,23 @@ dodo-migrate polar \
 - Add `--polar-organization-id` flag with specific organization ID
 - Get organization ID from Polar.sh dashboard or run in interactive mode first
 
-### "Product 'X' has N benefits which will not be migrated"
+### "Product 'X' has N benefits that require manual setup"
 
-**Cause**: Benefits are Polar-specific features not supported by Dodo Payments
+**Cause**: Non-license-key benefits are Polar-specific features not directly supported by Dodo Payments
 
 **Solution**:
-1. Migration will continue successfully
-2. Manually configure benefits in Dodo Payments:
-   - **License keys**: Use [Keygen](https://keygen.sh) or [LicenseSpring](https://licensespring.com) with webhooks
+1. License key benefits are handled by the `license_keys` migration type
+2. Other benefits must be configured manually in Dodo Payments:
    - **GitHub access**: Use GitHub Apps or manual invitations
    - **File downloads**: Use cloud storage (S3, GCS) with signed URLs
    - **Discord invites**: Use Discord bot with role assignment
+
+### "License key migration requires products and customers to be migrated in the same session"
+
+**Cause**: License keys need product and customer ID mappings that are built during migration
+
+**Solution**:
+- Re-run migration with all three types selected: `--migrate-types="products,customers,license_keys"`
 
 ### "Discount 'CODE' is restricted to specific products"
 
@@ -325,9 +357,9 @@ Individual failures don't stop migration - check logs for complete results.
 **Polar.sh API**: 300 requests per minute
 
 Migration handles rate limiting automatically:
-- Displays clear error messages
-- Shows retry wait time
-- Exits gracefully for retry
+- Adds 200ms delay between API calls to stay under limits
+- Retries with exponential backoff on 429 (rate limit) responses
+- Reads `retry-after` header when available
 
 **Large Migrations**:
 - 100 products → ~30 seconds

--- a/docs/polar/README.md
+++ b/docs/polar/README.md
@@ -130,7 +130,7 @@ dodo-migrate polar \
 ### ✅ License Keys
 
 **What's Migrated:**
-- License key strings (imported via Dodo's import API, marked as `source: "import"`)
+- License key strings
 - Activation limits
 - Expiration dates
 - Customer and product associations
@@ -144,7 +144,8 @@ dodo-migrate polar \
 - Polar `benefit_id` → resolved to Dodo `product_id` via benefit-to-product mapping
 - Polar `customer_id` → mapped to Dodo `customer_id`
 - `limit_activations` → `activations_limit` (null = unlimited in both systems)
-- `expires_at` → direct mapping (ISO 8601, null = perpetual)
+- `expires_at` → direct mapping (ISO 8601, null = perpetual)  
+⚠️ We are currently working on improving the stability of the `expires_at` parameter. It may contain bugs.
 
 **Limitations:**
 - ⚠️ **Revoked/disabled keys are skipped** (only `"granted"` status keys are migrated)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@lemonsqueezy/lemonsqueezy.js": "^4.0.0",
     "@polar-sh/sdk": "^0.35.4",
     "commander": "^14.0.2",
-    "dodopayments": "^2.14.2",
+    "dodopayments": "^2.28.0",
     "stripe": "^17.7.0",
     "yargs": "^18.0.0"
   },

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -92,6 +92,14 @@ export default {
         const productIdMap = new Map<string, string>();
         const customerIdMap = new Map<string, string>();
 
+        if (migrationTypes.includes('license_keys')) {
+            if (!migrationTypes.includes('products') || !migrationTypes.includes('customers')) {
+                logger.error('License key migration requires products and customers to be migrated in the same session.');
+                logger.error('Please re-run with products, customers, and license keys selected.');
+                process.exit(1);
+            }
+        }
+
         // Migrate products if selected
         if (migrationTypes.includes('products')) {
             logger.log('\nStarting products migration...');

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -405,7 +405,7 @@ export default {
 
                     if (licenseKeysResponse.error || licenseKeysResponse.statusCode !== 200) {
                         logger.error("Failed to fetch license keys from Lemon Squeezy!", licenseKeysResponse.error);
-                        break;
+                        process.exit(1);
                     }
 
                     if (licenseKeysResponse.data?.data?.length) {

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -3,6 +3,11 @@ import { input, select, checkbox } from '@inquirer/prompts';
 import { logger } from '../../utils/logger';
 import { delay, type LicenseKeyToMigrate } from '../../utils/common';
 import { getDodoCredentials, setupDodoClient, selectDodoBrand } from '../../utils/dodo';
+import { ProductCreateParams } from 'dodopayments/resources';
+import { Product } from 'dodopayments/resources.js';
+
+// This will be used for caching product information when required
+const DodoPaymentsProductCache: Record<string, Product> = {};
 
 export default {
     // Format: dodo-migrate [provider] [arguments]
@@ -81,7 +86,7 @@ export default {
         // I've cached this object to prevent rate limiting issues when dealing with multiple Lemon Squeezy products.
         const StoresData: Record<string, Store> = {};
 
-        const Products: { type: 'one_time_product', data: any, ls_product_id: string }[] = [];
+        const Products: { type: 'one_time_product', data: ProductCreateParams, ls_product_id: string }[] = [];
         const Coupons: { data: any }[] = [];
 
         let completedProducts = false;
@@ -158,14 +163,14 @@ export default {
                             ls_product_id: String(product.id),
                             migrated_from: 'lemonsqueezy',
                             migrated_at: new Date().toISOString()
-                        }
+                        },
                     }
                 });
             }
 
             logger.log('These are the products to be migrated:');
             Products.forEach((product, index) => {
-                logger.log(`${index + 1}. ${product.data.name} - ${product.data.price.currency} ${(product.data.price.price / 100).toFixed(2)} (${product.type === 'one_time_product' ? 'One Time' : 'Unknown'})`);
+                logger.log(`${index + 1}. ${product.data.name} - ${product.data.price.currency} ${((product.data.price as any).price / 100).toFixed(2)} (${product.type === 'one_time_product' ? 'One Time' : 'Unknown'})`);
             });
 
             // Ask the user for final confirmation before creating the products in Dodo Payments
@@ -491,7 +496,30 @@ export default {
 
                         for (const lk of licenseKeysToMigrate) {
                             await delay(100);
+
+                            // What I'm doing here is retriving the product info and caching it to prevent more reads
                             try {
+                                let product_info: Product;
+                                if (DodoPaymentsProductCache[lk.dodo_product_id]) {
+                                    product_info = DodoPaymentsProductCache[lk.dodo_product_id];
+                                } else {
+                                    const dodoProductData = await client.products.retrieve(lk.dodo_product_id);
+                                    DodoPaymentsProductCache[lk.dodo_product_id] = dodoProductData;
+                                    product_info = dodoProductData;
+                                }
+
+                                // Enable license key for the product so otherwise the migration will fail + update the cache
+                                // The reason I'm manually updating the product here is that LemonSqueezy doesn't provide a way to check if a product generates license key or not
+                                if (!product_info.license_key_enabled) {
+                                    await client.products.update(lk.dodo_product_id, {
+                                        license_key_enabled: true
+                                    });
+
+                                    logger.log(`Updating created product ${product_info.name} to enable license mode`);
+
+                                    DodoPaymentsProductCache[lk.dodo_product_id].license_key_enabled = true;
+                                }
+
                                 const created = await client.licenseKeys.create({
                                     key: lk.key,
                                     customer_id: lk.dodo_customer_id,

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -60,7 +60,7 @@ export default {
                     { name: 'Products', value: 'products', checked: true },
                     { name: 'Coupons/Discounts', value: 'coupons', checked: true },
                     { name: 'Customers', value: 'customers', checked: true },
-                    { name: 'License Keys', value: 'license_keys', checked: false }
+                    { name: 'License Keys', value: 'license_keys', checked: true }
                 ],
                 required: true
             });

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -1,7 +1,7 @@
-import { listProducts, lemonSqueezySetup, getStore, Store, listDiscounts, listCustomers } from '@lemonsqueezy/lemonsqueezy.js';
+import { listProducts, lemonSqueezySetup, getStore, Store, listDiscounts, listCustomers, listLicenseKeys } from '@lemonsqueezy/lemonsqueezy.js';
 import { input, select, checkbox } from '@inquirer/prompts';
 import { logger } from '../../utils/logger';
-import { delay } from '../../utils/common';
+import { delay, type LicenseKeyToMigrate } from '../../utils/common';
 import { getDodoCredentials, setupDodoClient, selectDodoBrand } from '../../utils/dodo';
 
 export default {
@@ -54,7 +54,8 @@ export default {
                 choices: [
                     { name: 'Products', value: 'products', checked: true },
                     { name: 'Coupons/Discounts', value: 'coupons', checked: true },
-                    { name: 'Customers', value: 'customers', checked: true }
+                    { name: 'Customers', value: 'customers', checked: true },
+                    { name: 'License Keys', value: 'license_keys', checked: false }
                 ],
                 required: true
             });
@@ -80,16 +81,16 @@ export default {
         // I've cached this object to prevent rate limiting issues when dealing with multiple Lemon Squeezy products.
         const StoresData: Record<string, Store> = {};
 
-        // This will be the array of products to be created in Dodo Payments
-        const Products: { type: 'one_time_product', data: any }[] = [];
-
-        // This will be the array of coupons to be created in Dodo Payments
+        const Products: { type: 'one_time_product', data: any, ls_product_id: string }[] = [];
         const Coupons: { data: any }[] = [];
 
-        // Track actual completion state for each migration branch
         let completedProducts = false;
         let completedCoupons = false;
         let completedCustomers = false;
+        let completedLicenseKeys = false;
+
+        const productIdMap = new Map<string, string>();
+        const customerIdMap = new Map<string, string>();
 
         // Migrate products if selected
         if (migrationTypes.includes('products')) {
@@ -131,9 +132,9 @@ export default {
                     StoreData = StoresData[product.attributes.store_id];
                 }
 
-                // Store the product data in the Products array to be created later in Dodo Payments
                 Products.push({
                     type: 'one_time_product',
+                    ls_product_id: String(product.id),
                     data: {
                         name: product.attributes.name,
                         tax_category: 'saas',
@@ -144,7 +145,12 @@ export default {
                             purchasing_power_parity: false,
                             type: 'one_time_price'
                         },
-                        brand_id: brand_id
+                        brand_id: brand_id,
+                        metadata: {
+                            ls_product_id: String(product.id),
+                            migrated_from: 'lemonsqueezy',
+                            migrated_at: new Date().toISOString()
+                        }
                     }
                 });
             }
@@ -164,17 +170,13 @@ export default {
             });
 
             if (migrateProducts === 'yes') {
-                // Iterate all the stored products and create them in Dodo Payments
                 for (let product of Products) {
-                    // Blank line for better readability in logs
                     logger.log('');
-                    // If the product type is one_time_product, invoke the client.products.create method
                     if (product.type === 'one_time_product') {
                         logger.log(`Migrating product: ${product.data.name}`);
-                        // Create the product in Dodo Payments
-                        // 10 req/s = 100ms delay
                         await delay(100);
                         const createdProduct = await client.products.create(product.data);
+                        productIdMap.set(product.ls_product_id, createdProduct.product_id);
                         logger.success(`Migration for product: ${createdProduct.name} completed (Dodo Payments product ID: ${createdProduct.product_id})`);
                     } else {
                         logger.log(`Skipping product: ${product.data.name} for unknown product type (example one time, subscription, etc)`);
@@ -336,7 +338,8 @@ export default {
                 }
 
                 // Iterate through all the pages of customers
-                while (currentPage <= customers.data?.meta.page.lastPage!) {
+                const lastPage = customers.data?.meta?.page?.lastPage ?? 1;
+                while (currentPage <= lastPage) {
                     // Fetch the next page of customers
                     // 5 req/s = 200ms delay
                     await delay(200);
@@ -353,12 +356,12 @@ export default {
                     }
 
                     for (const user of customersNew.data.data) {
-                        // 10 req/s = 100ms delay
                         await delay(100);
-                        await client.customers.create({
+                        const createdCustomer = await client.customers.create({
                             name: user.attributes.name!,
                             email: user.attributes.email!
                         });
+                        customerIdMap.set(user.attributes.email!, createdCustomer.customer_id);
                     }
 
                     currentPage++;
@@ -369,11 +372,150 @@ export default {
             }
         }
 
-        // Final completion message
+        if (migrationTypes.includes('license_keys')) {
+            if (productIdMap.size === 0 || customerIdMap.size === 0) {
+                logger.error('License key migration requires products and customers to be migrated in the same session.');
+                logger.error('Please re-run with products, customers, and license_keys selected.');
+            } else {
+                logger.log('\nStarting license keys migration...');
+
+                let currentLicensePage = 1;
+                let hasMoreLicenses = true;
+                const allLicenseKeys: any[] = [];
+
+                while (hasMoreLicenses) {
+                    await delay(200);
+                    const licenseKeysResponse = await listLicenseKeys({
+                        page: { number: currentLicensePage, size: 100 }
+                    });
+
+                    if (licenseKeysResponse.error || licenseKeysResponse.statusCode !== 200) {
+                        logger.error("Failed to fetch license keys from Lemon Squeezy!", licenseKeysResponse.error);
+                        break;
+                    }
+
+                    if (licenseKeysResponse.data?.data?.length) {
+                        allLicenseKeys.push(...licenseKeysResponse.data.data);
+                    }
+
+                    const lastPage = licenseKeysResponse.data?.meta?.page?.lastPage ?? currentLicensePage;
+                    hasMoreLicenses = currentLicensePage < lastPage;
+                    currentLicensePage++;
+                }
+
+                logger.log(`Found ${allLicenseKeys.length} license keys in Lemon Squeezy`);
+
+                const licenseKeysToMigrate: LicenseKeyToMigrate[] = [];
+                let skippedCount = 0;
+
+                for (const lk of allLicenseKeys) {
+                    const attrs = lk.attributes;
+
+                    if (attrs.disabled === 1 || attrs.status === 'disabled') {
+                        logger.log(`Skipping disabled license key: ${lk.id}`);
+                        skippedCount++;
+                        continue;
+                    }
+
+                    if (attrs.status === 'expired') {
+                        logger.log(`Skipping expired license key: ${lk.id}`);
+                        skippedCount++;
+                        continue;
+                    }
+
+                    const dodoProductId = productIdMap.get(String(attrs.product_id));
+                    if (!dodoProductId) {
+                        logger.warn(`License key ${lk.id}: no matching Dodo product for LS product ${attrs.product_id}. Skipping.`);
+                        skippedCount++;
+                        continue;
+                    }
+
+                    const dodoCustomerId = customerIdMap.get(attrs.user_email);
+                    if (!dodoCustomerId) {
+                        logger.warn(`License key ${lk.id}: no matching Dodo customer for email ${attrs.user_email}. Skipping.`);
+                        skippedCount++;
+                        continue;
+                    }
+
+                    const activationsLimit = attrs.activation_limit === 0 ? null : attrs.activation_limit;
+
+                    licenseKeysToMigrate.push({
+                        key: attrs.key,
+                        dodo_customer_id: dodoCustomerId,
+                        dodo_product_id: dodoProductId,
+                        activations_limit: activationsLimit,
+                        expires_at: attrs.expires_at || null,
+                        source_key_id: String(lk.id),
+                        display_key: `****${attrs.key.slice(-6)}`,
+                        product_name: `Product ${attrs.product_id}`,
+                        customer_email: attrs.user_email
+                    });
+                }
+
+                if (licenseKeysToMigrate.length === 0) {
+                    logger.log('No valid license keys found to migrate.');
+                } else {
+                    logger.log('\nThese are the license keys to be migrated:');
+                    licenseKeysToMigrate.forEach((lk, index) => {
+                        const limit = lk.activations_limit !== null ? `${lk.activations_limit} activations` : 'Unlimited';
+                        const expiry = lk.expires_at ? new Date(lk.expires_at).toLocaleDateString() : 'Never';
+                        logger.log(`${index + 1}. ${lk.display_key} - ${lk.customer_email} - ${limit} - Expires: ${expiry}`);
+                    });
+
+                    if (skippedCount > 0) {
+                        logger.warn(`${skippedCount} license keys were skipped (disabled/expired/unmapped)`);
+                    }
+
+                    const migrateLicenseKeysConfirm = await select({
+                        message: `Proceed to create ${licenseKeysToMigrate.length} license keys in Dodo Payments?`,
+                        choices: [
+                            { name: 'Yes', value: 'yes' },
+                            { name: 'No', value: 'no' }
+                        ],
+                    });
+
+                    if (migrateLicenseKeysConfirm === 'yes') {
+                        let lkSuccessCount = 0;
+                        let lkFailureCount = 0;
+
+                        for (const lk of licenseKeysToMigrate) {
+                            await delay(100);
+                            try {
+                                const created = await client.licenseKeys.create({
+                                    key: lk.key,
+                                    customer_id: lk.dodo_customer_id,
+                                    product_id: lk.dodo_product_id,
+                                    activations_limit: lk.activations_limit,
+                                    expires_at: lk.expires_at,
+                                });
+                                logger.success(`Migrated license key: ${lk.display_key} (Dodo ID: ${created.id})`);
+                                lkSuccessCount++;
+                            } catch (error: any) {
+                                if (error.status === 409) {
+                                    logger.warn(`License key ${lk.display_key} already exists in Dodo. Skipping.`);
+                                } else {
+                                    logger.error(`Failed to migrate license key ${lk.display_key}: ${error.message}`);
+                                }
+                                lkFailureCount++;
+                            }
+                        }
+
+                        logger.log(`\nLicense keys migration complete: ${lkSuccessCount} succeeded, ${lkFailureCount} failed`);
+                        if (lkSuccessCount > 0) {
+                            completedLicenseKeys = true;
+                        }
+                    } else {
+                        logger.log('License keys migration aborted by user');
+                    }
+                }
+            }
+        }
+
         const completedMigrations: string[] = [];
         if (completedProducts) completedMigrations.push('products');
         if (completedCoupons) completedMigrations.push('coupons');
         if (completedCustomers) completedMigrations.push('customers');
+        if (completedLicenseKeys) completedMigrations.push('license_keys');
 
         if (completedMigrations.length > 0) {
             logger.success(`Migration completed for: ${completedMigrations.join(', ')}`);

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -361,7 +361,7 @@ export default {
                             name: user.attributes.name!,
                             email: user.attributes.email!
                         });
-                        customerIdMap.set(user.attributes.email!, createdCustomer.customer_id);
+                        customerIdMap.set(user.attributes.email!.trim().toLowerCase(), createdCustomer.customer_id);
                     }
 
                     currentPage++;
@@ -376,6 +376,7 @@ export default {
             if (productIdMap.size === 0 || customerIdMap.size === 0) {
                 logger.error('License key migration requires products and customers to be migrated in the same session.');
                 logger.error('Please re-run with products, customers, and license_keys selected.');
+                process.exit(1);
             } else {
                 logger.log('\nStarting license keys migration...');
 
@@ -430,7 +431,8 @@ export default {
                         continue;
                     }
 
-                    const dodoCustomerId = customerIdMap.get(attrs.user_email);
+                    const normalizedEmail = attrs.user_email?.trim().toLowerCase();
+                    const dodoCustomerId = normalizedEmail ? customerIdMap.get(normalizedEmail) : undefined;
                     if (!dodoCustomerId) {
                         logger.warn(`License key ${lk.id}: no matching Dodo customer for email ${attrs.user_email}. Skipping.`);
                         skippedCount++;
@@ -477,6 +479,7 @@ export default {
                     if (migrateLicenseKeysConfirm === 'yes') {
                         let lkSuccessCount = 0;
                         let lkFailureCount = 0;
+                        let lkDuplicateCount = 0;
 
                         for (const lk of licenseKeysToMigrate) {
                             await delay(100);
@@ -493,15 +496,16 @@ export default {
                             } catch (error: any) {
                                 if (error.status === 409) {
                                     logger.warn(`License key ${lk.display_key} already exists in Dodo. Skipping.`);
+                                    lkDuplicateCount++;
                                 } else {
                                     logger.error(`Failed to migrate license key ${lk.display_key}: ${error.message}`);
+                                    lkFailureCount++;
                                 }
-                                lkFailureCount++;
                             }
                         }
 
-                        logger.log(`\nLicense keys migration complete: ${lkSuccessCount} succeeded, ${lkFailureCount} failed`);
-                        if (lkSuccessCount > 0) {
+                        logger.log(`\nLicense keys migration complete: ${lkSuccessCount} succeeded, ${lkDuplicateCount} duplicates skipped, ${lkFailureCount} failed`);
+                        if (lkSuccessCount > 0 || lkDuplicateCount > 0) {
                             completedLicenseKeys = true;
                         }
                     } else {

--- a/src/providers/lemonsqueezy/index.ts
+++ b/src/providers/lemonsqueezy/index.ts
@@ -383,7 +383,7 @@ export default {
         if (migrationTypes.includes('license_keys')) {
             if (productIdMap.size === 0 || customerIdMap.size === 0) {
                 logger.error('License key migration requires products and customers to be migrated in the same session.');
-                logger.error('Please re-run with products, customers, and license_keys selected.');
+                logger.error('Please re-run with products, customers, and license keys selected.');
                 process.exit(1);
             } else {
                 logger.log('\nStarting license keys migration...');

--- a/src/providers/polar/index.ts
+++ b/src/providers/polar/index.ts
@@ -164,6 +164,14 @@ export default {
         let benefitToProductMap = new Map<string, string>();
         let customerIdMap = new Map<string, string>();
 
+        if (migrateTypes.includes('license_keys')) {
+            if (!migrateTypes.includes('products') || !migrateTypes.includes('customers')) {
+                logger.error('License key migration requires products and customers to be migrated in the same session.');
+                logger.error('Please re-run with products, customers, and license keys selected.');
+                process.exit(1);
+            }
+        }
+
         if (migrateTypes.includes('products')) {
             const result = await migrateProducts(polar, client, organization_id, brand_id);
             if (result.completed) completedMigrations.push('products');
@@ -185,7 +193,7 @@ export default {
         if (migrateTypes.includes('license_keys')) {
             if (productIdMap.size === 0 || customerIdMap.size === 0) {
                 logger.error('License key migration requires products and customers to be migrated in the same session.');
-                logger.error('Please re-run with products, customers, and license_keys selected.');
+                logger.error('Please re-run with products, customers, and license keys selected.');
                 process.exit(1);
             } else {
                 const completed = await migrateLicenseKeys(polar, client, organization_id, productIdMap, customerIdMap, benefitToProductMap);

--- a/src/providers/polar/index.ts
+++ b/src/providers/polar/index.ts
@@ -4,6 +4,7 @@ import { select, checkbox, password } from '@inquirer/prompts';
 import { logger } from '../../utils/logger';
 import { getDodoCredentials, setupDodoClient, selectDodoBrand } from '../../utils/dodo';
 import { delay, retryWithBackoff, type LicenseKeyToMigrate } from '../../utils/common';
+import { Product } from '@polar-sh/sdk/models/components/product.js';
 
 export default {
     command: 'polar [arguments]',
@@ -149,8 +150,8 @@ export default {
                     choices: [
                         { name: 'Products', value: 'products', checked: true },
                         { name: 'Discounts', value: 'discounts', checked: true },
-                        { name: 'Customers', value: 'customers', checked: false },
-                        { name: 'License Keys', value: 'license_keys', checked: false }
+                        { name: 'Customers', value: 'customers', checked: true },
+                        { name: 'License Keys', value: 'license_keys', checked: true }
                     ],
                     required: true
                 });
@@ -215,7 +216,7 @@ interface ProductToMigrate {
     type: 'one_time_product' | 'subscription_product';
     polar_id: string;
     data: any; // Using any to match Stripe provider pattern
-    benefits: Array<{ description: string }>;
+    benefits: Array<{ description: string, type: 'license_keys' | string }>;
 }
 
 async function migrateProducts(polar: Polar, client: any, organization_id: string, brand_id: string): Promise<{ completed: boolean; idMap: Map<string, string>; benefitToProductMap: Map<string, string> }> {
@@ -225,7 +226,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
 
     try {
         logger.log('Fetching products from Polar.sh...');
-        const products: any[] = [];
+        const products: Product[] = [];
         let page = 1;
         let hasMore = true;
         while (hasMore) {
@@ -256,12 +257,17 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
             // Build benefit→product reverse map for license key resolution
             if (product.benefits && product.benefits.length > 0) {
                 for (const benefit of product.benefits) {
-                    if (benefit.id) {
-                        benefitToProductMap.set(benefit.id, product.id);
-                    }
+                    benefitToProductMap.set(benefit.id, product.id);
                 }
-                logger.warn(`Product "${product.name}" has ${product.benefits.length} benefits that require manual setup.`);
             }
+
+            const manualBenefits = product.benefits.filter(e => e.type !== 'license_keys');
+            if (manualBenefits.length > 0) {
+                logger.warn(`Product "${product.name}" has ${manualBenefits.length} benefits that require manual setup.`);
+            }
+
+            // Enable licence key generation for Dodo Payments product if the product is configured with license generation on Polar
+            const isLicenseKeyEnabled = product.benefits.some(e => e.type === 'license_keys');
 
             // Process each price variant in the product
             const prices = product.prices || [];
@@ -330,6 +336,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
                             name: variantName,
                             description: product.description || '',
                             tax_category: 'saas',
+                            license_key_enabled: isLicenseKeyEnabled,
                             price: {
                                 currency: priceCurrency.toUpperCase(),
                                 price: priceAmount,
@@ -344,7 +351,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
                             },
                             brand_id: brand_id
                         },
-                        benefits: (product.benefits || []).map((b: any) => ({ description: b.description }))
+                        benefits: (product.benefits || []).map((b: any) => ({ description: b.description, type: b.type }))
                     });
                 } else {
                     // One-time product
@@ -355,6 +362,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
                             name: variantName,
                             description: product.description || '',
                             tax_category: 'saas',
+                            license_key_enabled: isLicenseKeyEnabled,
                             price: {
                                 currency: priceCurrency.toUpperCase(),
                                 price: priceAmount,
@@ -364,7 +372,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
                             },
                             brand_id: brand_id
                         },
-                        benefits: (product.benefits || []).map((b: any) => ({ description: b.description }))
+                        benefits: (product.benefits || []).map((b: any) => ({ description: b.description, type: b.type }))
                     });
                 }
             }
@@ -389,7 +397,8 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
             logger.log(`   Price: ${product.data.price.currency} ${price.toFixed(2)}`);
             logger.log(`   Polar ID: ${product.polar_id}`);
 
-            if (product.benefits.length > 0) {
+            // Filter the license key benefits since that's managed by us
+            if (product.benefits.filter(e => e.type !== 'license_keys').length > 0) {
                 logger.log(`   ⚠️  Benefits (${product.benefits.length}): Requires manual setup`);
                 product.benefits.forEach((benefit, idx) => {
                     logger.log(`     ${idx + 1}. ${benefit.description}`);
@@ -430,6 +439,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
                     migrated_from: 'polar',
                     migrated_at: new Date().toISOString()
                 };
+
                 const createdProduct = await client.products.create(product.data);
                 if (!idMap.has(product.polar_id)) {
                     idMap.set(product.polar_id, createdProduct.product_id);

--- a/src/providers/polar/index.ts
+++ b/src/providers/polar/index.ts
@@ -186,6 +186,7 @@ export default {
             if (productIdMap.size === 0 || customerIdMap.size === 0) {
                 logger.error('License key migration requires products and customers to be migrated in the same session.');
                 logger.error('Please re-run with products, customers, and license_keys selected.');
+                process.exit(1);
             } else {
                 const completed = await migrateLicenseKeys(polar, client, organization_id, productIdMap, customerIdMap, benefitToProductMap);
                 if (completed) completedMigrations.push('license_keys');
@@ -422,7 +423,9 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
                     migrated_at: new Date().toISOString()
                 };
                 const createdProduct = await client.products.create(product.data);
-                idMap.set(product.polar_id, createdProduct.product_id);
+                if (!idMap.has(product.polar_id)) {
+                    idMap.set(product.polar_id, createdProduct.product_id);
+                }
                 logger.success(`Migrated: ${product.data.name} (Dodo ID: ${createdProduct.product_id})`);
                 successCount++;
             } catch (error: any) {
@@ -907,6 +910,7 @@ async function migrateLicenseKeys(
 
         let successCount = 0;
         let errorCount = 0;
+        let duplicateCount = 0;
 
         for (const lk of licenseKeysToMigrate) {
             try {
@@ -922,19 +926,23 @@ async function migrateLicenseKeys(
             } catch (error: any) {
                 if (error.status === 409) {
                     logger.warn(`License key ${lk.display_key} already exists in Dodo. Skipping.`);
+                    duplicateCount++;
                 } else {
                     logger.error(`Failed to migrate license key ${lk.display_key}: ${error.message}`);
+                    errorCount++;
                 }
-                errorCount++;
             }
         }
 
         logger.log('\n=== License Keys Migration Complete ===');
         logger.log(`Successfully migrated: ${successCount} license keys`);
+        if (duplicateCount > 0) {
+            logger.log(`Duplicates skipped: ${duplicateCount}`);
+        }
         if (errorCount > 0) {
             logger.warn(`Errors encountered: ${errorCount}`);
         }
-        return successCount > 0;
+        return successCount > 0 || duplicateCount > 0;
     } catch (error: any) {
         logger.error('Failed to migrate license keys!', error.message);
         return false;

--- a/src/providers/polar/index.ts
+++ b/src/providers/polar/index.ts
@@ -3,6 +3,7 @@ import DodoPayments from 'dodopayments';
 import { select, checkbox, password } from '@inquirer/prompts';
 import { logger } from '../../utils/logger';
 import { getDodoCredentials, setupDodoClient, selectDodoBrand } from '../../utils/dodo';
+import { delay, retryWithBackoff, type LicenseKeyToMigrate } from '../../utils/common';
 
 export default {
     command: 'polar [arguments]',
@@ -31,7 +32,7 @@ export default {
                 demandOption: false
             })
             .option('migrate-types', {
-                describe: 'Types of data to migrate (comma-separated: products,discounts,customers)',
+                describe: 'Types of data to migrate (comma-separated: products,discounts,customers,license_keys)',
                 type: 'string',
                 demandOption: false,
             })
@@ -80,11 +81,14 @@ export default {
             let page = 1;
             let hasMore = true;
             while (hasMore) {
-                const response = await polar.organizations.list({ page });
+                await delay(200);
+                const response = await retryWithBackoff(
+                    () => polar.organizations.list({ page }),
+                    { label: 'polar.organizations.list' }
+                );
                 if (response.result?.items?.length) {
                     organizations.push(...response.result.items);
                 }
-                // Check if there are more pages based on pagination metadata
                 const pagination = response.result?.pagination;
                 hasMore = pagination ? page < pagination.maxPage : false;
                 page++;
@@ -97,12 +101,6 @@ export default {
                 process.exit(1);
             }
         } catch (error: any) {
-            // Check for rate limiting (429 Too Many Requests)
-            if (error.statusCode === 429 || error.status === 429) {
-                const retryAfter = error.headers?.['retry-after'] || error.response?.headers?.['retry-after'] || 'unknown';
-                logger.error(`Polar.sh API rate limit exceeded (300 requests/minute). Retry after ${retryAfter} seconds.`);
-                process.exit(1);
-            }
             logger.error('Failed to connect to Polar.sh');
             logger.error('Please check your Organization Access Token at https://polar.sh/settings/tokens');
             process.exit(1);
@@ -151,7 +149,8 @@ export default {
                     choices: [
                         { name: 'Products', value: 'products', checked: true },
                         { name: 'Discounts', value: 'discounts', checked: true },
-                        { name: 'Customers', value: 'customers', checked: false }
+                        { name: 'Customers', value: 'customers', checked: false },
+                        { name: 'License Keys', value: 'license_keys', checked: false }
                     ],
                     required: true
                 });
@@ -160,12 +159,16 @@ export default {
 
         logger.log(`Will migrate: ${migrateTypes.join(', ')}`);
 
-        // Execute the selected migrations
         const completedMigrations: string[] = [];
+        let productIdMap = new Map<string, string>();
+        let benefitToProductMap = new Map<string, string>();
+        let customerIdMap = new Map<string, string>();
 
         if (migrateTypes.includes('products')) {
-            const completed = await migrateProducts(polar, client, organization_id, brand_id);
-            if (completed) completedMigrations.push('products');
+            const result = await migrateProducts(polar, client, organization_id, brand_id);
+            if (result.completed) completedMigrations.push('products');
+            productIdMap = result.idMap;
+            benefitToProductMap = result.benefitToProductMap;
         }
 
         if (migrateTypes.includes('discounts')) {
@@ -174,8 +177,19 @@ export default {
         }
 
         if (migrateTypes.includes('customers')) {
-            const completed = await migrateCustomers(polar, client, organization_id, brand_id);
-            if (completed) completedMigrations.push('customers');
+            const result = await migrateCustomers(polar, client, organization_id, brand_id);
+            if (result.completed) completedMigrations.push('customers');
+            customerIdMap = result.idMap;
+        }
+
+        if (migrateTypes.includes('license_keys')) {
+            if (productIdMap.size === 0 || customerIdMap.size === 0) {
+                logger.error('License key migration requires products and customers to be migrated in the same session.');
+                logger.error('Please re-run with products, customers, and license_keys selected.');
+            } else {
+                const completed = await migrateLicenseKeys(polar, client, organization_id, productIdMap, customerIdMap, benefitToProductMap);
+                if (completed) completedMigrations.push('license_keys');
+            }
         }
 
         if (completedMigrations.length > 0) {
@@ -195,37 +209,33 @@ interface ProductToMigrate {
     benefits: Array<{ description: string }>;
 }
 
-async function migrateProducts(polar: Polar, client: any, organization_id: string, brand_id: string): Promise<boolean> {
+async function migrateProducts(polar: Polar, client: any, organization_id: string, brand_id: string): Promise<{ completed: boolean; idMap: Map<string, string>; benefitToProductMap: Map<string, string> }> {
     logger.log('\n=== Starting Products Migration ===');
+    const idMap = new Map<string, string>();
+    const benefitToProductMap = new Map<string, string>();
 
     try {
         logger.log('Fetching products from Polar.sh...');
         const products: any[] = [];
-        try {
-            let page = 1;
-            let hasMore = true;
-            while (hasMore) {
-                const response = await polar.products.list({ organizationId: organization_id, page });
-                if (response.result?.items?.length) {
-                    products.push(...response.result.items);
-                }
-                const pagination = response.result?.pagination;
-                hasMore = pagination ? page < pagination.maxPage : false;
-                page++;
+        let page = 1;
+        let hasMore = true;
+        while (hasMore) {
+            await delay(200);
+            const response = await retryWithBackoff(
+                () => polar.products.list({ organizationId: organization_id, page }),
+                { label: 'polar.products.list' }
+            );
+            if (response.result?.items?.length) {
+                products.push(...response.result.items);
             }
-        } catch (error: any) {
-            // Check for rate limiting (429 Too Many Requests)
-            if (error.statusCode === 429 || error.status === 429) {
-                const retryAfter = error.headers?.['retry-after'] || error.response?.headers?.['retry-after'] || 'unknown';
-                logger.error(`Polar.sh API rate limit exceeded (300 requests/minute). Retry after ${retryAfter} seconds.`);
-                process.exit(1);
-            }
-            throw error;
+            const pagination = response.result?.pagination;
+            hasMore = pagination ? page < pagination.maxPage : false;
+            page++;
         }
 
         if (products.length === 0) {
             logger.log('No products found in Polar.sh. Skipping products migration.');
-            return false;
+            return { completed: false, idMap, benefitToProductMap };
         }
 
         logger.log(`Found ${products.length} products to migrate`);
@@ -234,8 +244,13 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
         const productsToMigrate: ProductToMigrate[] = [];
 
         for (const product of products) {
-            // Warn if product has benefits (license keys, GitHub access, etc.) that can't be migrated
+            // Build benefit→product reverse map for license key resolution
             if (product.benefits && product.benefits.length > 0) {
+                for (const benefit of product.benefits) {
+                    if (benefit.id) {
+                        benefitToProductMap.set(benefit.id, product.id);
+                    }
+                }
                 logger.warn(`Product "${product.name}" has ${product.benefits.length} benefits that require manual setup.`);
             }
 
@@ -348,7 +363,7 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
 
         if (productsToMigrate.length === 0) {
             logger.log('No compatible products found to migrate.');
-            return false;
+            return { completed: false, idMap, benefitToProductMap };
         }
 
         // Show preview of products that will be migrated
@@ -392,36 +407,39 @@ async function migrateProducts(polar: Polar, client: any, organization_id: strin
 
         if (shouldProceed !== 'yes') {
             logger.log('Products migration cancelled by user.');
-            return false;
+            return { completed: false, idMap, benefitToProductMap };
         }
 
-        // Create products in Dodo Payments
         logger.log('\n[LOG] Starting products migration...');
         let successCount = 0;
         let errorCount = 0;
 
         for (const product of productsToMigrate) {
             try {
+                product.data.metadata = {
+                    polar_product_id: product.polar_id,
+                    migrated_from: 'polar',
+                    migrated_at: new Date().toISOString()
+                };
                 const createdProduct = await client.products.create(product.data);
+                idMap.set(product.polar_id, createdProduct.product_id);
                 logger.success(`Migrated: ${product.data.name} (Dodo ID: ${createdProduct.product_id})`);
                 successCount++;
             } catch (error: any) {
-                // Continue migrating other products even if one fails
                 logger.error(`Failed to migrate product "${product.data.name}": ${error.message}`);
                 errorCount++;
             }
         }
 
-        // Display migration summary
         logger.log('\n=== Products Migration Complete ===');
         logger.log(`Successfully migrated: ${successCount} products`);
         if (errorCount > 0) {
             logger.warn(`Errors encountered: ${errorCount}`);
         }
-        return true;
+        return { completed: true, idMap, benefitToProductMap };
     } catch (error: any) {
         logger.error('Failed to migrate products!', error.message);
-        return false;
+        return { completed: false, idMap, benefitToProductMap };
     }
 }
 
@@ -436,26 +454,20 @@ async function migrateDiscounts(polar: Polar, client: DodoPayments, organization
     try {
         logger.log('Fetching discounts from Polar.sh...');
         const discounts: any[] = [];
-        try {
-            let page = 1;
-            let hasMore = true;
-            while (hasMore) {
-                const response = await polar.discounts.list({ organizationId: organization_id, page });
-                if (response.result?.items?.length) {
-                    discounts.push(...response.result.items);
-                }
-                const pagination = response.result?.pagination;
-                hasMore = pagination ? page < pagination.maxPage : false;
-                page++;
+        let page = 1;
+        let hasMore = true;
+        while (hasMore) {
+            await delay(200);
+            const response = await retryWithBackoff(
+                () => polar.discounts.list({ organizationId: organization_id, page }),
+                { label: 'polar.discounts.list' }
+            );
+            if (response.result?.items?.length) {
+                discounts.push(...response.result.items);
             }
-        } catch (error: any) {
-            // Check for rate limiting (429 Too Many Requests)
-            if (error.statusCode === 429 || error.status === 429) {
-                const retryAfter = error.headers?.['retry-after'] || error.response?.headers?.['retry-after'] || 'unknown';
-                logger.error(`Polar.sh API rate limit exceeded (300 requests/minute). Retry after ${retryAfter} seconds.`);
-                process.exit(1);
-            }
-            throw error;
+            const pagination = response.result?.pagination;
+            hasMore = pagination ? page < pagination.maxPage : false;
+            page++;
         }
 
         if (discounts.length === 0) {
@@ -628,37 +640,32 @@ interface CustomerToMigrate {
     };
 }
 
-async function migrateCustomers(polar: Polar, client: DodoPayments, organization_id: string, brand_id: string): Promise<boolean> {
+async function migrateCustomers(polar: Polar, client: DodoPayments, organization_id: string, brand_id: string): Promise<{ completed: boolean; idMap: Map<string, string> }> {
     logger.log('\n[LOG] === Starting Customers Migration ===');
+    const idMap = new Map<string, string>();
 
     try {
         logger.log('Fetching customers from Polar.sh...');
         const customers: any[] = [];
-        try {
-            let page = 1;
-            let hasMore = true;
-            while (hasMore) {
-                const response = await polar.customers.list({ organizationId: organization_id, page });
-                if (response.result?.items?.length) {
-                    customers.push(...response.result.items);
-                }
-                const pagination = response.result?.pagination;
-                hasMore = pagination ? page < pagination.maxPage : false;
-                page++;
+        let page = 1;
+        let hasMore = true;
+        while (hasMore) {
+            await delay(200);
+            const response = await retryWithBackoff(
+                () => polar.customers.list({ organizationId: organization_id, page }),
+                { label: 'polar.customers.list' }
+            );
+            if (response.result?.items?.length) {
+                customers.push(...response.result.items);
             }
-        } catch (error: any) {
-            // Check for rate limiting (429 Too Many Requests)
-            if (error.statusCode === 429 || error.status === 429) {
-                const retryAfter = error.headers?.['retry-after'] || error.response?.headers?.['retry-after'] || 'unknown';
-                logger.error(`Polar.sh API rate limit exceeded (300 requests/minute). Retry after ${retryAfter} seconds.`);
-                process.exit(1);
-            }
-            throw error;
+            const pagination = response.result?.pagination;
+            hasMore = pagination ? page < pagination.maxPage : false;
+            page++;
         }
 
         if (customers.length === 0) {
             logger.log('No customers found in Polar.sh. Skipping customers migration.');
-            return false;
+            return { completed: false, idMap };
         }
 
         logger.log(`Found ${customers.length} customers to process`);
@@ -717,7 +724,7 @@ async function migrateCustomers(polar: Polar, client: DodoPayments, organization
 
         if (customersToMigrate.length === 0) {
             logger.log('No valid customers found to migrate.');
-            return false;
+            return { completed: false, idMap };
         }
 
         // Show preview of customers that will be migrated
@@ -751,10 +758,9 @@ async function migrateCustomers(polar: Polar, client: DodoPayments, organization
 
         if (shouldProceed !== 'yes') {
             logger.log('Customers migration cancelled by user.');
-            return false;
+            return { completed: false, idMap };
         }
 
-        // Create customers in Dodo Payments
         logger.log('\nStarting customers migration...');
         let successCount = 0;
         let errorCount = 0;
@@ -762,6 +768,7 @@ async function migrateCustomers(polar: Polar, client: DodoPayments, organization
         for (const customer of customersToMigrate) {
             try {
                 const createdCustomer = await client.customers.create(customer as any);
+                idMap.set(customer.metadata.polar_customer_id, createdCustomer.customer_id);
                 logger.success(`Migrated: ${customer.name || customer.email} (Dodo ID: ${createdCustomer.customer_id})`);
                 successCount++;
             } catch (error: any) {
@@ -770,15 +777,166 @@ async function migrateCustomers(polar: Polar, client: DodoPayments, organization
             }
         }
 
-        // Display migration summary
         logger.log('\n[LOG] === Customers Migration Complete ===');
         logger.log(`Successfully migrated: ${successCount} customers`);
         if (errorCount > 0) {
             logger.warn(`Errors encountered: ${errorCount}`);
         }
-        return true;
+        return { completed: true, idMap };
     } catch (error: any) {
         logger.error('Failed to migrate customers!', error.message);
+        return { completed: false, idMap };
+    }
+}
+
+async function migrateLicenseKeys(
+    polar: Polar,
+    client: any,
+    organization_id: string,
+    productIdMap: Map<string, string>,
+    customerIdMap: Map<string, string>,
+    benefitToProductMap: Map<string, string>
+): Promise<boolean> {
+    logger.log('\n=== Starting License Keys Migration ===');
+
+    try {
+        logger.log('Fetching license keys from Polar.sh...');
+        const allKeys: any[] = [];
+        let page = 1;
+        let hasMore = true;
+        while (hasMore) {
+            await delay(200);
+            const response = await retryWithBackoff(
+                () => polar.licenseKeys.list({ organizationId: organization_id, page, limit: 100 }),
+                { label: 'polar.licenseKeys.list' }
+            );
+            if (response.result?.items?.length) {
+                allKeys.push(...response.result.items);
+            }
+            const pagination = response.result?.pagination;
+            hasMore = pagination ? page < pagination.maxPage : false;
+            page++;
+        }
+
+        if (allKeys.length === 0) {
+            logger.log('No license keys found in Polar.sh. Skipping license keys migration.');
+            return false;
+        }
+
+        logger.log(`Found ${allKeys.length} license keys to process`);
+
+        const licenseKeysToMigrate: LicenseKeyToMigrate[] = [];
+        let skippedCount = 0;
+
+        for (const key of allKeys) {
+            if (key.status === 'revoked' || key.status === 'disabled') {
+                logger.log(`Skipping ${key.status} license key: ${key.id}`);
+                skippedCount++;
+                continue;
+            }
+
+            const polarProductId = benefitToProductMap.get(key.benefitId);
+            if (!polarProductId) {
+                logger.warn(`License key ${key.id}: cannot resolve benefit ${key.benefitId} to a product. Skipping.`);
+                skippedCount++;
+                continue;
+            }
+
+            const dodoProductId = productIdMap.get(polarProductId);
+            if (!dodoProductId) {
+                logger.warn(`License key ${key.id}: no matching Dodo product for Polar product ${polarProductId}. Skipping.`);
+                skippedCount++;
+                continue;
+            }
+
+            const dodoCustomerId = customerIdMap.get(key.customerId);
+            if (!dodoCustomerId) {
+                logger.warn(`License key ${key.id}: no matching Dodo customer for Polar customer ${key.customerId}. Skipping.`);
+                skippedCount++;
+                continue;
+            }
+
+            licenseKeysToMigrate.push({
+                key: key.key,
+                dodo_customer_id: dodoCustomerId,
+                dodo_product_id: dodoProductId,
+                activations_limit: key.limitActivations ?? null,
+                expires_at: key.expiresAt ?? null,
+                source_key_id: key.id,
+                display_key: `****${key.key.slice(-6)}`,
+                product_name: 'Product ' + polarProductId,
+                customer_email: key.customer?.email || 'Unknown'
+            });
+        }
+
+        if (licenseKeysToMigrate.length === 0) {
+            logger.log('No valid license keys found to migrate.');
+            return false;
+        }
+
+        logger.log('\n[PREVIEW] License keys to be migrated:');
+        logger.log('=====================================');
+        licenseKeysToMigrate.forEach((lk, index) => {
+            const limit = lk.activations_limit !== null ? `${lk.activations_limit} activations` : 'Unlimited';
+            const expiry = lk.expires_at ? new Date(lk.expires_at).toLocaleDateString() : 'Never';
+            logger.log(`${index + 1}. ${lk.display_key} - ${lk.customer_email} - ${limit} - Expires: ${expiry}`);
+        });
+        if (skippedCount > 0) {
+            logger.warn(`${skippedCount} license keys were skipped (revoked/disabled/unmapped)`);
+        }
+        logger.log('=====================================');
+
+        let shouldProceed = 'yes';
+        if (process.stdin.isTTY) {
+            const { select } = await import('@inquirer/prompts');
+            shouldProceed = await select({
+                message: `Proceed with migrating ${licenseKeysToMigrate.length} license keys to Dodo Payments?`,
+                choices: [
+                    { name: 'Yes', value: 'yes' },
+                    { name: 'No', value: 'no' }
+                ]
+            });
+        } else {
+            logger.log('Non-interactive mode: proceeding with license keys migration automatically');
+        }
+
+        if (shouldProceed !== 'yes') {
+            logger.log('License keys migration cancelled by user.');
+            return false;
+        }
+
+        let successCount = 0;
+        let errorCount = 0;
+
+        for (const lk of licenseKeysToMigrate) {
+            try {
+                const created = await client.licenseKeys.create({
+                    key: lk.key,
+                    customer_id: lk.dodo_customer_id,
+                    product_id: lk.dodo_product_id,
+                    activations_limit: lk.activations_limit,
+                    expires_at: lk.expires_at,
+                });
+                logger.success(`Migrated license key: ${lk.display_key} (Dodo ID: ${created.id})`);
+                successCount++;
+            } catch (error: any) {
+                if (error.status === 409) {
+                    logger.warn(`License key ${lk.display_key} already exists in Dodo. Skipping.`);
+                } else {
+                    logger.error(`Failed to migrate license key ${lk.display_key}: ${error.message}`);
+                }
+                errorCount++;
+            }
+        }
+
+        logger.log('\n=== License Keys Migration Complete ===');
+        logger.log(`Successfully migrated: ${successCount} license keys`);
+        if (errorCount > 0) {
+            logger.warn(`Errors encountered: ${errorCount}`);
+        }
+        return successCount > 0;
+    } catch (error: any) {
+        logger.error('Failed to migrate license keys!', error.message);
         return false;
     }
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,1 +1,50 @@
+import { logger } from './logger';
+
 export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Retry async fn with exponential backoff on 429 (rate limit).
+ * Reads retry-after header when available, otherwise exponential delay.
+ */
+export async function retryWithBackoff<T>(
+    fn: () => Promise<T>,
+    options: { maxRetries?: number; baseDelay?: number; label?: string } = {}
+): Promise<T> {
+    const { maxRetries = 3, baseDelay = 1000, label = 'API call' } = options;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            return await fn();
+        } catch (error: any) {
+            const status = error.statusCode ?? error.status ?? error?.response?.status;
+            if (status === 429 && attempt < maxRetries) {
+                const retryAfter = error.headers?.['retry-after']
+                    ?? error.response?.headers?.['retry-after'];
+                const waitMs = retryAfter
+                    ? parseInt(retryAfter, 10) * 1000
+                    : baseDelay * Math.pow(2, attempt);
+
+                logger.warn(`Rate limited on ${label} (attempt ${attempt + 1}/${maxRetries}). Retrying in ${Math.round(waitMs / 1000)}s...`);
+                await delay(waitMs);
+                continue;
+            }
+            throw error;
+        }
+    }
+
+    throw new Error(`${label}: max retries exceeded`);
+}
+
+export interface LicenseKeyToMigrate {
+    key: string;
+    /** Dodo customer ID (mapped from source) */
+    dodo_customer_id: string;
+    /** Dodo product ID (mapped from source) */
+    dodo_product_id: string;
+    activations_limit: number | null;
+    expires_at: string | null;
+    source_key_id: string;
+    display_key: string;
+    product_name: string;
+    customer_email: string;
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -20,9 +20,18 @@ export async function retryWithBackoff<T>(
             if (status === 429 && attempt < maxRetries) {
                 const retryAfter = error.headers?.['retry-after']
                     ?? error.response?.headers?.['retry-after'];
-                const waitMs = retryAfter
-                    ? parseInt(retryAfter, 10) * 1000
-                    : baseDelay * Math.pow(2, attempt);
+                let waitMs = baseDelay * Math.pow(2, attempt);
+                if (retryAfter) {
+                    const parsed = parseInt(retryAfter, 10);
+                    if (!isNaN(parsed)) {
+                        waitMs = parsed * 1000;
+                    } else {
+                        const dateMs = Date.parse(retryAfter);
+                        if (!isNaN(dateMs)) {
+                            waitMs = Math.max(0, dateMs - Date.now());
+                        }
+                    }
+                }
 
                 logger.warn(`Rate limited on ${label} (attempt ${attempt + 1}/${maxRetries}). Retrying in ${Math.round(waitMs / 1000)}s...`);
                 await delay(waitMs);


### PR DESCRIPTION
## Summary

- Add license key migration support for **Polar.sh** and **LemonSqueezy** using Dodo's new `client.licenseKeys.create()` API (SDK v2.28.0)
- Add `retryWithBackoff()` utility with exponential backoff on 429 rate limit errors, replacing the previous crash-on-429 behavior in the Polar provider
- Add `delay(200ms)` between all Polar API calls to proactively prevent rate limiting

## What Changed

### Shared Utilities (`src/utils/common.ts`)
- New `retryWithBackoff()` — generic retry wrapper that reads `retry-after` headers on 429 responses
- New `LicenseKeyToMigrate` interface — shared schema for both providers

### Polar Provider (`src/providers/polar/index.ts`)
- **Rate limiting**: All Polar API pagination loops now use `delay(200ms)` + `retryWithBackoff()` instead of `process.exit(1)` on 429
- **ID mapping**: `migrateProducts()` and `migrateCustomers()` now return `Map<polar_id, dodo_id>` for cross-entity lookups
- **Metadata**: Product creation includes `metadata: { polar_product_id, migrated_from, migrated_at }` for traceability
- **Benefit→Product map**: During product migration, builds a reverse map of `benefit_id → polar_product_id` so license keys can resolve their product association without extra API calls
- **New `migrateLicenseKeys()`**: Fetches all license keys, resolves benefit→product→dodo_product, maps customers, previews, confirms, creates in Dodo

### LemonSqueezy Provider (`src/providers/lemonsqueezy/index.ts`)
- **ID mapping**: Product and customer creation loops now capture `Map<ls_id, dodo_id>` and `Map<email, dodo_customer_id>`
- **Metadata**: Product creation includes `metadata: { ls_product_id, migrated_from, migrated_at }`
- **New license key migration block**: Fetches all LS license keys (paginated), maps to Dodo products/customers, handles LS quirks (activation_limit 0 → null, disabled as 0/1 int), creates in Dodo
- **Fix**: Resolved pre-existing lint error (forbidden non-null assertion after optional chaining)

### SDK Update
- `dodopayments`: 2.14.2 → 2.28.0 (adds `client.licenseKeys.create()`)

### Docs
- Updated Polar, LemonSqueezy, and root README with license key migration details

## Key Design Decisions

1. **License keys require products + customers in same session** — ID mappings are in-memory, so all three must be migrated together
2. **Revoked/disabled/expired keys are skipped** — only active keys are migrated, with warnings logged
3. **409 (duplicate) is handled gracefully** — supports idempotent re-runs
4. **Polar benefit resolution is zero-cost** — reverse map built during product fetch, no extra API calls needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added license key migration support for Polar and Lemon Squeezy (preview, confirm, create; idempotent handling of duplicates).

* **Performance / Reliability**
  * Improved rate-limiting behavior with 200ms base delay, exponential backoff, honoring Retry-After, and retries on 429 responses.

* **Documentation**
  * Updated migration guides with license-key migration steps, requirements, mappings, limitations, and troubleshooting.

* **Dependencies**
  * Bumped dodopayments to v2.28.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->