### PR TITLE
ci: npm Trusted Publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,13 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -58,8 +65,6 @@ jobs:
         run: bun run build
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
 


### PR DESCRIPTION
## What

Switch npm publishing from a long-lived `NPM_TOKEN` secret to **npm Trusted Publishing over GitHub Actions OIDC** — no token in CI.

## Changes

- **Upgrade npm to `11.6.2`** after `setup-node` (OIDC trusted publishing requires npm >= 11.5.1; the Node version here ships an older npm). Pinned for reproducibility — 11.5.2 fixed an OIDC/provenance ordering bug and 11.6.2 resolves trusted-publishing failures seen in the wild.
- **Drop `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`** from the publish step(s).
- (no extra permission changes needed — id-token: write and --provenance were already present.)

## Required before the next release (npmjs.com side — cannot be done from code)

Each published package must have a **trusted publisher** registered on npmjs.com pointing at this repo + the workflow file `.github/workflows/publish.yml`, or the first OIDC publish fails auth. This is being handled out-of-band per package (`npm trust github ... --repository dodopayments/dodo-migrate --file publish.yml --allow-publish`). A brand-new package needs a manual first publish before OIDC can take over.

## Why

- Removes a long-lived, exfiltration-prone credential from CI.
- OIDC tokens are short-lived and cryptographically scoped to this workflow file + commit SHA.
- Mirrors the proven conversion in `dodopayments/dualmark` (#91).
